### PR TITLE
fix `relative module was not found` error when having nuxt `srcDir` set

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -111,7 +111,7 @@ export default function ContentModule(moduleOpts) {
 		src: resolve(__dirname, 'plugin.js'),
 		options: {
 			...options,
-			srcDirFromPlugin: join('../', srcDir) // TODO
+			srcDirFromPlugin: join('~/', srcDir)
 		}
 	})
 }


### PR DESCRIPTION
fixes #55