### PR TITLE
Changed baseURL to empty string; fixes #53

### DIFF
--- a/lib/module.js
+++ b/lib/module.js
@@ -45,7 +45,7 @@ export default function ContentModule(moduleOpts) {
 		srcDir: '/content',
 		componentsDir: '/components',
 		buildDir: `/content`,
-		isStatic: userOptions.isStatic || process.env.STATIC || false, 
+		isStatic: userOptions.isStatic || process.env.STATIC || false,
 
 		content: contentOptions(userOptions.content, {
 			page: null,
@@ -65,7 +65,7 @@ export default function ContentModule(moduleOpts) {
 		},
 
 		api: {
-			baseURL: `http://${host}:${port}`,
+			baseURL: '',
 			...userOptions.api,
 			serverPrefix: `/content-api`,
 			browserPrefix: `/_nuxt/content`


### PR DESCRIPTION
whole api path gets interpreted as relative by axios (by default) now; resolve #53 