### PR TITLE
Change Prism implementation to include classes

### DIFF
--- a/docs/content/Configuration.md
+++ b/docs/content/Configuration.md
@@ -106,7 +106,7 @@ module.exports = {
   parsers: {
     md: {
       highlight: (code, lang) => {
-        return Prism.highlight(code, Prism.languages[lang] || Prism.languages.markup)
+        return `<pre class="language-${lang}"><code class="language-${lang}">${Prism.highlight(code, Prism.languages[lang] || Prism.languages.markup)}</code></pre>`
       }
     }
   }


### PR DESCRIPTION
In the old example, Prism will return the `<code></code>` blocks correctly, but it won't style the external `<pre></pre>` blocks, which is what defines the background of the code section.

This update means Prism will now have the correct `<pre><code></code></pre>` setup with all the classes in place, so you get the background of your theme too.