### PR TITLE
fixes link to config page from intro

### DIFF
--- a/docs/content/Introduction.md
+++ b/docs/content/Introduction.md
@@ -23,5 +23,5 @@ There you go: four reasons to give Nuxtent a try, and maybe even star and share 
 
 There are two main steps to using `nuxtent`:
 
-1) [Configuring how you want your content data compiled](/configuration)
+1) [Configuring how you want your content data compiled](configuration)
 2) [Dynamically fetching and rendering the content data inside Nuxt pages](usage)


### PR DESCRIPTION
In the guide, the intro page had a faulty link to the `configuration` page, as it had a prefix of `/`, unlike the `usage` page which had none and worked as expected on nuxtent.now.sh. This should correct it to resolve to the relative path inside of `/guide/`.