### PR TITLE
Closes #69. Allow .yml file extension for content files.

### DIFF
--- a/lib/content/page.js
+++ b/lib/content/page.js
@@ -147,7 +147,7 @@ export default function prepPage(meta, options, isDev) {
           cached.body = parsers
             .mdParser(parsers.md, options)
             .render(_rawData.body) // markdown to html
-        } else if (fileName.search(/\.yaml$/) > -1) {
+        } else if (fileName.search(/\.(yaml|yml)$/) > -1) {
           cached.body = parsers.yamlParser().render(_rawData.body) // yaml to json
         }
       }
@@ -177,7 +177,7 @@ export default function prepPage(meta, options, isDev) {
         if (meta.fileName.search(/\.md$/) > -1) {
           const { attributes, body } = fm(source)
           cached.data = { attributes, body }
-        } else if (meta.fileName.search(/\.yaml$/) > -1) {
+        } else if (meta.fileName.search(/\.(yaml|yml)$/) > -1) {
           cached.data = { attributes: {}, body: source }
         }
       }


### PR DESCRIPTION
I enhanced the regular expression a little.