### PR TITLE
Fixes #96. Do not expose filePath to the browser.

### DIFF
--- a/lib/content/page.js
+++ b/lib/content/page.js
@@ -59,7 +59,9 @@ export default function prepPage(meta, options, isDev) {
     },
 
     get meta() {
-      return meta
+      const cleanedMeta = Object.assign({}, meta)
+      delete cleanedMeta.filePath
+      return cleanedMeta
     },
 
     get path() {


### PR DESCRIPTION
The JSON that is exposed to the client does not need the absolute filePath in any case. Remove it when exposing.