### PR TITLE
Modify mdParser to offer config extension like nuxtjs and expose an hook for customizing of created parser

### DIFF
--- a/lib/util/parsers.js
+++ b/lib/util/parsers.js
@@ -2,7 +2,7 @@ import yamlit from 'js-yaml'
 import markdownit from 'markdown-it'
 import markdownAnchors from 'markdown-it-anchor'
 
-export const mdParser = ({ configureHook, postConstructionHook }, { anchorsLevel }) => {
+export const mdParser = ( md , { anchorsLevel }) => {
 
   var config = {
     preset: 'default',
@@ -11,8 +11,8 @@ export const mdParser = ({ configureHook, postConstructionHook }, { anchorsLevel
     linkify: true,
   }
   
-  if (configureHook !== undefined ){
-    configureHook(config)
+  if (md.extend !== undefined ){
+    md.extend(config)
   }
 
   const parser = markdownit(config)
@@ -24,7 +24,7 @@ export const mdParser = ({ configureHook, postConstructionHook }, { anchorsLevel
         level: [anchorsLevel]
       }
     ]
-  ]
+  ].concat(md.plugins)
 
   plugins.forEach(plugin => {
     Array.isArray(plugin)
@@ -32,8 +32,8 @@ export const mdParser = ({ configureHook, postConstructionHook }, { anchorsLevel
       : parser.use(plugin)
   })
 
-  if (postConstructionHook !== undefined ){
-    postConstructionHook(parser)
+  if (md.customize !== undefined ){
+    md.customize(parser)
   }
 
   return parser

--- a/lib/util/parsers.js
+++ b/lib/util/parsers.js
@@ -2,7 +2,7 @@ import yamlit from 'js-yaml'
 import markdownit from 'markdown-it'
 import markdownAnchors from 'markdown-it-anchor'
 
-export const mdParser = ({ highlight, use }, { anchorsLevel }) => {
+export const mdParser = ({ highlight, use, rules }, { anchorsLevel }) => {
   const parser = markdownit({
     preset: 'default',
     html: true,
@@ -25,6 +25,10 @@ export const mdParser = ({ highlight, use }, { anchorsLevel }) => {
       ? parser.use.apply(parser, plugin)
       : parser.use(plugin)
   })
+
+  for (var key in rules){
+    parser.renderer.rules[key] = rules[key]
+  }
 
   return parser
 }

--- a/lib/util/parsers.js
+++ b/lib/util/parsers.js
@@ -1,9 +1,36 @@
 import yamlit from 'js-yaml'
 import markdownit from 'markdown-it'
+import markdownAnchors from 'markdown-it-anchor'
 
-export const mdParser = ({ config, postConstructionHook }) => {
+export const mdParser = ({ config, postConstructionHook }, { anchorsLevel }) => {
 
-  const parser = markdownit(config)
+  var baseConfig = {
+    preset: 'default',
+    html: true,
+    typographer: true,
+    linkify: true,
+  }
+
+  for( var key in config ){
+    baseConfig[key] = config[key]
+  }
+
+  const parser = markdownit(baseConfig)
+
+  const plugins = [
+    [
+      markdownAnchors,
+      {
+        level: [anchorsLevel]
+      }
+    ]
+  ]
+
+  plugins.forEach(plugin => {
+    Array.isArray(plugin)
+      ? parser.use.apply(parser, plugin)
+      : parser.use(plugin)
+  })
 
   if (postConstructionHook !== undefined ){
     postConstructionHook(parser)

--- a/lib/util/parsers.js
+++ b/lib/util/parsers.js
@@ -2,20 +2,20 @@ import yamlit from 'js-yaml'
 import markdownit from 'markdown-it'
 import markdownAnchors from 'markdown-it-anchor'
 
-export const mdParser = ({ config, postConstructionHook }, { anchorsLevel }) => {
+export const mdParser = ({ configureHook, postConstructionHook }, { anchorsLevel }) => {
 
-  var baseConfig = {
+  var config = {
     preset: 'default',
     html: true,
     typographer: true,
     linkify: true,
   }
-
-  for( var key in config ){
-    baseConfig[key] = config[key]
+  
+  if (configureHook !== undefined ){
+    configureHook(config)
   }
 
-  const parser = markdownit(baseConfig)
+  const parser = markdownit(config)
 
   const plugins = [
     [

--- a/lib/util/parsers.js
+++ b/lib/util/parsers.js
@@ -2,7 +2,8 @@ import yamlit from 'js-yaml'
 import markdownit from 'markdown-it'
 import markdownAnchors from 'markdown-it-anchor'
 
-export const mdParser = ({ highlight, use, rules }, { anchorsLevel }) => {
+export const mdParser = ({ highlight, use, postConstructionHook }, { anchorsLevel }) => {
+
   const parser = markdownit({
     preset: 'default',
     html: true,
@@ -26,8 +27,8 @@ export const mdParser = ({ highlight, use, rules }, { anchorsLevel }) => {
       : parser.use(plugin)
   })
 
-  for (var key in rules){
-    parser.renderer.rules[key] = rules[key]
+  if (postConstructionHook !== undefined ){
+    postConstructionHook(parser)
   }
 
   return parser

--- a/lib/util/parsers.js
+++ b/lib/util/parsers.js
@@ -1,31 +1,9 @@
 import yamlit from 'js-yaml'
 import markdownit from 'markdown-it'
-import markdownAnchors from 'markdown-it-anchor'
 
-export const mdParser = ({ highlight, use, postConstructionHook }, { anchorsLevel }) => {
+export const mdParser = ({ config, postConstructionHook }) => {
 
-  const parser = markdownit({
-    preset: 'default',
-    html: true,
-    typographer: true,
-    linkify: true,
-    highlight
-  })
-
-  const plugins = [
-    [
-      markdownAnchors,
-      {
-        level: [anchorsLevel]
-      }
-    ]
-  ].concat(use)
-
-  plugins.forEach(plugin => {
-    Array.isArray(plugin)
-      ? parser.use.apply(parser, plugin)
-      : parser.use(plugin)
-  })
+  const parser = markdownit(config)
 
   if (postConstructionHook !== undefined ){
     postConstructionHook(parser)


### PR DESCRIPTION
To support the [twemoji](https://github.com/twitter/twemoji) output for [markdown-it-emoji](https://github.com/markdown-it/markdown-it-emoji), I had to figure out how to pass the described mapping function to the rules object of markdown-it.

Example from [markdown-it-emoji](https://github.com/markdown-it/markdown-it-emoji):
```
md.renderer.rules.emoji = function(token, idx) {
  return twemoji.parse(token[idx].content);
};
```
So I extended the mdParser so that it receives rules that are specified within the config and passes them to the markdown parser. An example for a config file shows like this:
```
var emoji = require('markdown-it-emoji');
var twemoji = require('twemoji')

module.exports = {
  content: {
    permalink: ':slug',
    page: '/_content',
    generate: [ // for static build
      'get', 'getAll'
    ],
    isPost: false
  },
  parsers: {
    md: {
        use: [
            emoji
        ],
        rules: {
            emoji: function(token, idx) {
                return twemoji.parse(token[idx].content);
            }
        }
    }
  }
}
```