### PR TITLE
add new option 'generatePathPrefix' in nuxtent.config to let user config dynamic generate path

### DIFF
--- a/lib/content/build.js
+++ b/lib/content/build.js
@@ -119,7 +119,13 @@ const buildContent = (nuxt, buildDir, isStatic, options) => {
               throw new Error('You must specify a page path')
             }
             db.findAll(req['query']).forEach(page => {
-              routePages.push(page.permalink)
+              if (dirOpts.generatePathPrefix) {
+                routePages.push(
+                  join(dirOpts.generatePathPrefix, page.permalink)
+                )
+              } else {
+                routePages.push(page.permalink)
+              }
               assetMap.set(buildPath(page.permalink, dirName, buildDir), page)
             })
             break


### PR DESCRIPTION
Hi. I made this update so users can config the generated prefix for their content page.
For example, in my issue #118, I can write my config as
```javascript
  content: [
    [
      'project/node/',
      {
        page: 'project/node/_slug',
        permalink: '/:slug',
        isPost: false,
        generate: ['get', 'getAll'],
        generatePathPrefix: 'project/node'
      }
    ]
  ]
```
instead of
```javascript
  content: [
    [
      'project/node/',
      {
        page: 'project/node/_slug',
        permalink: 'project/node/:slug',
        isPost: false,
        generate: ['get', 'getAll']
      }
    ]
  ]
```