### PR TITLE
Lose trailing slash before making browserPath from permalink

### DIFF
--- a/lib/plugins/requestContent.js
+++ b/lib/plugins/requestContent.js
@@ -33,8 +33,9 @@ export default ({ app, isStatic, hotReload, route }) => {
       }
       return cache[apiEndpoint]
     } else if (process.client) {
+      const trailingSlash = /\/$/
       const allButFirstSlash = /(?!^\/)(\/)/g
-      const serializedPermalink = permalink.replace(allButFirstSlash, '.')
+      const serializedPermalink = permalink.replace(trailingSlash, '').replace(allButFirstSlash, '.')
       const browserPath = join(path, serializedPermalink) + '.json'
       if (!cache[browserPath]) {
         cache[browserPath] = (await app.$axios.get(browserPath)).data


### PR DESCRIPTION
I found what I think is a problem working with static web servers that redirect paths that point to a filesystem directory, expecting to pick up something like index.html from that directory, to insist on a slash at the end of the path. AWS S3 does this, I think without an option to disable it.

A Nuxt /page like /pages/PageItem.vue prerenders to /page-item/index.html. Similarly, /content/ContentItem prerenders through /pages/_content.vue to /content-item/index.html. When loaded from an S3 bucket like http://s3.server.com/page-item S3 helpfully redirects to "http://s3.server.com/page-item/". The page loads and rerenders in the browser.

A similar request for http://s3.server.com/content-item also gets redirected, to "http://s3.server.com/content-item/", but here things go wrong. requestContent.js builds a metadata request from the permalink by replacing all slashes but the first with dots, then appends '.json'. That leaves axios requesting "whatever/content-item..json" and getting 404.

I think the fix is to strip any trailing slash from the permalink when generating serializedPermalink in requestContent.js, something like this:

       const trailingSlash = /\/$/
       const allButFirstSlash = /(?!^\/)(\/)/g
       const serializedPermalink = permalink.replace(trailingSlash, '').replace(allButFirstSlash, '.')

With this in place the problem seems gone in my S3 testing. I'm brand new to nuxtent so please view this with skepticism, but it might be helpful in other static hosting situations.
