### PR TITLE
Update markdown-it-anchor package to 5+

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "js-yaml": "^3.10.0",
     "loader-utils": "^1.1.0",
     "markdown-it": "^8.4.0",
-    "markdown-it-anchor": "^4.0.0",
+    "markdown-it-anchor": "^5.0.0",
     "param-case": "^2.1.1",
     "path-to-regexp": "^2.0.0",
     "uppercamelcase": "^3.0.0"


### PR DESCRIPTION
Markdown-it-anchor removed the dependency on the string package which has a known security vulnerability. 

https://github.com/valeriangalliat/markdown-it-anchor/blob/master/CHANGELOG.md
https://www.npmjs.com/advisories/536